### PR TITLE
Fix loading data with channels having different units

### DIFF
--- a/fileio/file_readBV.m
+++ b/fileio/file_readBV.m
@@ -371,7 +371,17 @@ for filePos = firstFileToRead:lastFileToRead
   % read the data, read_bv will set the data in cnt.x because of the
   % read_opt.data options
   read_bv([fileNames{filePos} '.eeg'], read_hdr, read_opt);
-  cnt.yUnit= hdr{filePos}.unit;
+  if isfield(hdr{filePos},'unit')     
+    cnt.yUnit= hdr{filePos}.unit;
+ end
+ if isfield(hdr{filePos},'unitOfClab')
+    cnt.yUnit= hdr{filePos}.unitOfClab;
+ end
+ 
+ if ~isfield(cnt, 'yUnit')
+     ME = MException('InvalidUnits','Could not read units of the channels from the header file');
+     throw(ME);
+ end
 
   %% Markers
   if nargout>1,


### PR DESCRIPTION
The reading function file_readBV does not support EEG recordings containing channels with different units (for example when recording other physiological signals)
