### PR TITLE
restraining bbci_import_dependencies.

### DIFF
--- a/misc/bbci_import_dependencies.m
+++ b/misc/bbci_import_dependencies.m
@@ -1,4 +1,4 @@
-function bbci_import_dependencies(lib)
+function download_success = bbci_import_dependencies(lib)
 % IMPORT_IMPORT_DEPENDENCIES(LIB) - imports code from other toolboxes
 %
 % Other toolboxes might be published on copy-left licences such as GPL.
@@ -8,7 +8,7 @@ function bbci_import_dependencies(lib)
 % license. This script downloads the corresponding code and copies it into
 % the folder 'external' and genereates corresponding subfolders.
 %
-% If the subfolder already exists, then it is 
+% If the subfolder already exists, then the import fails with a warning.
 %
 %
 %Usage:
@@ -21,15 +21,17 @@ function bbci_import_dependencies(lib)
 if nargin == 0
     lib = '*';
 end
+fprintf('Trying to import dependencies\n');
 global BTB
 ext_folder = fullfile(BTB.Dir, 'external');
+download_success = 0;
 switch lower(lib)
     case '*'
         disp('checking dependencies and downloading external sources if necessary...')
         all_libs = {'fastica', 'ssd+spoc', 'mara'};        
         for kk = 1:length(all_libs)
             %recursive loop ^^
-            bbci_import_dependencies(all_libs{kk});
+            success = bbci_import_dependencies(all_libs{kk});
         end
     case 'ssd+spoc'        
         this_folder = fullfile(ext_folder, lower(lib));
@@ -37,7 +39,7 @@ switch lower(lib)
             try %download and unzip
                 download_success = 0;
                 this_zipfile = 'https://github.com/svendaehne/matlab_SPoC/archive/master.zip';
-                disp(['...Downloading ' lower(lib) ' from github'])
+                disp(sprintf(['\n\n\n...Downloading ' lower(lib) ' from github']))
                 download_success = try_download_unzip(this_zipfile, ext_folder);
                 movefile(fullfile(ext_folder, 'matlab_SPoC-master'), this_folder)
             catch
@@ -48,6 +50,8 @@ switch lower(lib)
                     fprintf(['Likely reason: \n(A) Matlab does not have the permission to write files into the folder. \n(B) no online access.\n\n Possible solution is to start Matlab as root. \n\nFor manual download:\n\n (1) download the zip-file: \n' this_zipfile '\n\n (2) unzip to ''' this_folder '''\n']);
                 end
             end
+        else
+            warning(['Could not import ' lib ', because the folder external/' lower(lib) 'already existed! Please delete this folder to refresh the import.'])
         end
     case 'fastica'
         this_folder = fullfile(ext_folder, lower(lib));
@@ -56,7 +60,7 @@ switch lower(lib)
             try %download and unzip
                 download_success = 0;
                 this_zipfile = 'http://research.ics.aalto.fi/ica/fastica/code/FastICA_2.5.zip';
-                disp(['...Downloading ' lower(lib) ' from http://research.ics.aalto.fi'])
+                disp(sprintf(['\n\n\n...Downloading ' lower(lib) ' from http://research.ics.aalto.fi']))
                 download_success = try_download_unzip(this_zipfile, ext_folder);
                 movefile(fullfile(ext_folder, 'FastICA_25'), this_folder)
             catch
@@ -68,8 +72,8 @@ switch lower(lib)
                     
                 end
             end
-%         else
-%             warning(['folder ' this_folder 'aleady exists. Skipping import of ' lib '. Please delete this folder to refresh the import.'])
+        else
+            warning(['Could not import ' lib ', because the folder external/' lower(lib) 'already existed! Please delete this folder to refresh the import.'])
         end
     case 'mara'
         this_folder = fullfile(ext_folder, lower(lib));
@@ -78,7 +82,7 @@ switch lower(lib)
             try %download and unzip
                 download_success = 0;
                 this_zipfile = 'http://www.user.tu-berlin.de/irene.winkler/artifacts/MARAtrdata.zip';
-                disp(['...Downloading ' lower(lib) ' from http://www.user.tu-berlin.de/irene.winkler/'])
+                disp(sprintf(['\n\n\n...Downloading ' lower(lib) ' from http://www.user.tu-berlin.de/irene.winkler/']))
                 download_success = try_download_unzip(this_zipfile, ext_folder);
                 movefile(fullfile(ext_folder, 'MARAtrdata'), this_folder)
             catch
@@ -89,13 +93,14 @@ switch lower(lib)
                     fprintf(['Likely reason: \n(A) Matlab does not have the permission to write files into the folder. \n(B) no online access.\n\n Possible solution is to start Matlab as root. \n\nFor manual download:\n\n (1) download the zip-file: \n' this_zipfile '\n\n (2) unzip to ''' this_folder '''\n']);                    
                 end
             end
-%         else
-%             warning(['folder ' this_folder 'aleady exists. Skipping import of ' lib '. Please delete this folder to refresh the import.'])
+        else
+            warning(['Could not import ' lib ', because the folder external/' lower(lib) 'already existed! Please delete this folder to refresh the import.'])
         end
     otherwise
         error('dependency not specified')
 end
 end
+
 
 
 function success = try_download_unzip(this_zipfile, ext_folder)
@@ -115,7 +120,7 @@ try
     urlwrite(this_zipfile, tmp_file);
 %     (2) unzip (OS-dependent)
     if isunix
-        system(['unzip ' tmp_file ' -d ' ext_folder]);
+        [status,cmdout] = system(['unzip ' tmp_file ' -d ' ext_folder]);
     else
         unzip(fullfile([ext_folder '/temp_download.zip']), ext_folder);
     end

--- a/startup_bbci_toolbox.m
+++ b/startup_bbci_toolbox.m
@@ -48,7 +48,22 @@ props= {'Dir'            BBCI_DIR          'CHAR';
 [BTB, isdefault]= opt_setDefaults(BTB, props);
 
 % import dependencies if not done yet
-bbci_import_dependencies()
+if ~exist(fullfile(BTB.Dir, 'external', 'auto_import_performed'), 'file')
+    inp = input(sprintf(['\nThis is the first startup of the BBCI toolbox - Wellcome!\n\n', ...
+        'You can now automatically download and import code from other sources.\n', ...
+        'This adds additional functionalities such as ICA and SSD to the BBCI toolbox.\n',...
+        'Following startups won''t ask for automatic imports. Manual imports are\n',...
+        'possible with ""bbci_import_dependencies()"" at any time.\n\n',...
+        'Type <yes> to download all dependencies (approx 10MB): ']), 's');
+    if strcmp(inp, 'yes') || strcmp(inp, 'y')
+        bbci_import_dependencies()
+        % write into file
+        fileID = fopen(fullfile(BTB.Dir, 'external', 'auto_import_performed'),'w');
+        fprintf(fileID,datestr(now()) );
+        fclose(fileID);
+    end
+end
+
 addpath(genpath(BBCI_DIR));
 rmpath(genpath(fullfile(BBCI_DIR, '.git')));
 


### PR DESCRIPTION
 Adding promt at the first startup only. Showing less output when downloading packages. fixes #65
