### PR TITLE
closes #100

### DIFF
--- a/fileio/file_readBVheader.m
+++ b/fileio/file_readBVheader.m
@@ -150,7 +150,7 @@ else
   occurrences= cellfun(@(x)(length(strmatch(x,hdr.unitOfClab,'exact'))), ...
                        units);
   [mm, midx]= max(occurrences);
-  unit= units{midx};
+  hdr.unit= units{midx};
 end
 
 check= getEntry(fid, '[Coordinates]', 0, -1);


### PR DESCRIPTION
Otherwise you can't load header or eeg files that contain two or more different units, because the field "hdr.unit" is required at a later stage.
