### PR TITLE
Added logistic regression classification functions. Closes issue #74.

### DIFF
--- a/classification/apply_logisticRegression.m
+++ b/classification/apply_logisticRegression.m
@@ -23,7 +23,8 @@ function out = apply_logisticRegression(C, X, varargin)
 %   apply_logisticRegression(C, X))
 %   
 %See also:
-%   LOGISTICREGRESSION
+%   TRAIN_LOGISTICREGRESSION
+
 
 props= {'OriginalOutput'      0                             'BOOL'
        };

--- a/classification/apply_logisticRegression.m
+++ b/classification/apply_logisticRegression.m
@@ -1,0 +1,45 @@
+function out = apply_logisticRegression(C, X, varargin)
+% APPLY_LOGISTICREGRESSION - Apply existing logistic regresion classifier
+%
+%Synopsis:
+%   C = apply_logisticRegression(C, X)
+%
+%Arguments:
+%   X: DOUBLE [NxM] - Data matrix, with N features and M samples. 
+%   C: STRUCT           - a logistic regression classifier structure.  Must include the
+%                           field 'b'.
+%   OPT: PROPLIST       - Structure or property/value list of optional
+%                           properties. Options are also passed to clsutil_shrinkage.
+%     'OriginalOutput'  - BOOL (default 0): If true, the orginal logistic regression output is returned (range [0 1])
+%Returns:
+%   out: FLOAT[]        - an array containing the classifier score for each 
+%                           sample, in range [-1 1] (or alternatively [0 1])
+%Description:
+%   APPLY_LOGISTICREGRESSION applies a logistic regresion classifier given data and a
+%   trained LR classifier.
+%
+%
+%Examples:
+%   apply_logisticRegression(C, X))
+%   
+%See also:
+%   LOGISTICREGRESSION
+
+props= {'OriginalOutput'      0                             'BOOL'
+       };
+
+
+opt= opt_proplistToStruct(varargin{:});
+[opt, isdefault]= opt_setDefaults(opt, props);
+opt_checkProplist(opt, props);
+
+misc_checkType(X, 'DOUBLE');
+misc_checkType(C, 'STRUCT(b)');
+
+pihat = mnrval(C.b, X');
+
+pihat = pihat';
+out = pihat(1,:);
+if ~opt.OriginalOutput
+  out = 2*(out - 0.5);
+end

--- a/classification/logisticRegression.m
+++ b/classification/logisticRegression.m
@@ -1,0 +1,34 @@
+function C = logisticRegression(XTr, YTr)
+% LOGISTICREGRESSION - Logistic regresion classifier
+%
+%Synopsis:
+%   C = logisticRegression(XTr, YTr)
+%
+%Arguments:
+%   XTR: DOUBLE [NxM] - Data matrix, with N feature dimensions, and M training points/examples. 
+%   YTR: INT [CxM] - Class membership labels of points in X_TR. C by M matrix of training
+%                     labels, with C representing the number of classes and M the number of training examples/points.
+%                     Y_TR(i,j)==1 if the point j belongs to class i.
+%Returns:
+%   C: STRUCT           - Structure containing the b coefficients of the logit model, trained on the data.
+%                             The structure C includes the field:
+%       'b': STRUCT     - coefficients of the classifier
+%
+%Description:
+%   LOGISTICREGRESSION trains a logisctic regression classifier given training data and labels.
+%
+
+%
+%
+%Examples:
+%     logisticRegression(XTr, YTr)
+%   
+%See also:
+%   APPLY_LOGISTICREGRESSION
+
+misc_checkType(XTr, 'DOUBLE[- -]');
+misc_checkType(YTr, 'DOUBLE[2 -]');
+
+B = mnrfit(XTr', categorical(YTr(1,:))');
+
+C.b = B;

--- a/classification/train_logisticRegression.m
+++ b/classification/train_logisticRegression.m
@@ -1,8 +1,8 @@
-function C = logisticRegression(XTr, YTr)
-% LOGISTICREGRESSION - Logistic regresion classifier
+function C = train_logisticRegression(XTr, YTr)
+% TRAIN_LOGISTICREGRESSION - Logistic regresion classifier
 %
 %Synopsis:
-%   C = logisticRegression(XTr, YTr)
+%   C = train_logisticRegression(XTr, YTr)
 %
 %Arguments:
 %   XTR: DOUBLE [NxM] - Data matrix, with N feature dimensions, and M training points/examples. 
@@ -15,13 +15,13 @@ function C = logisticRegression(XTr, YTr)
 %       'b': STRUCT     - coefficients of the classifier
 %
 %Description:
-%   LOGISTICREGRESSION trains a logisctic regression classifier given training data and labels.
+%   TRAIN_LOGISTICREGRESSION trains a logisctic regression classifier given training data and labels.
 %
 
 %
 %
 %Examples:
-%     logisticRegression(XTr, YTr)
+%     train_logisticRegression(XTr, YTr)
 %   
 %See also:
 %   APPLY_LOGISTICREGRESSION


### PR DESCRIPTION
Here are the train and apply logistic regression functions, which are compatible with the function crossvalidation. The 'train_' prefix is missing from the train function in order to make it work with crossvalidation, which would otherwise choose the wrong apply function.
