### PR TITLE
Modified HLDA function to properly work with crossvalidation

### DIFF
--- a/classification/HLDA.m
+++ b/classification/HLDA.m
@@ -1,8 +1,8 @@
-function C = train_HLDA(XTr, YTr, nSegments, varargin)
-% TRAIN_HLDA - Hierarchical linear discriminant analysis 
+function C = HLDA(XTr, YTr, nSegments, varargin)
+% HLDA - Hierarchical linear discriminant analysis 
 %
 %Synopsis:
-%   C = train_HLDA(XTr, YTr, nSegments, varargin)
+%   C = HLDA(XTr, YTr, nSegments, varargin)
 %
 %Arguments:
 %   XTR: DOUBLE [TxNxM] - Data matrix, with T temporal features, N
@@ -17,16 +17,20 @@ function C = train_HLDA(XTr, YTr, nSegments, varargin)
 %                           should be separated in  
 %   OPT: PROPLIST       - Structure or property/value list of optional
 %                           properties. Options are also passed to clsutil_shrinkage.
-%     'Regression' - BOOL (default 0): If true, the top level classifier is
+%     'Regression'  - BOOL (default 0): If true, the top level classifier is
 %                           a logistic regression classifier. 
+%     'nChannels'   - INT (default 0): Used when using 'crossvalidation' in order to 
+%                           reconstruct the 2D feature matrix to its original 3D
+%                           [T x Ch x N] shape.
 %Returns:
 %   C: STRUCT           - Structure containing the trained classifiers for
 %                           each segment and the final top level
 %                           classifier. The structure C includes the fields:
-%       'seg': STRUCT []    - contains a trained LDA classifier for each segment
-%       'final': STRUCT     - the final top-level LDA classifier
+%       'seg': STRUCT []      - contains a trained LDA classifier for each segment
+%       'final': STRUCT       - the final top-level LDA classifier
+%       'nChannels': INT      - (optional) the number of channels in the training data
 %Description:
-%   TRAIN_HLDA trains a hierarchical LDA classifier given training data,
+%   HLDA trains a hierarchical LDA classifier given training data,
 %   labels and a number of segments. Either LDA (default) or logistic regression 
 %   is used as a top-level classifier.
 %
@@ -37,14 +41,15 @@ function C = train_HLDA(XTr, YTr, nSegments, varargin)
 %
 %
 %Examples:
-%   train_HLDA(XTr, YTr, nSegments)
-%   train_HLDA(XTr, YTr, nSegments, 'Regression', 1)
+%   HLDA(XTr, YTr, nSegments)
+%   HLDA(XTr, YTr, nSegments, 'Regression', 1, 'nChannels', 64)
 %   
 %See also:
 %   APPLY_HLDA
 
 
 props= {'Regression'      0                             'BOOL'
+        'nChannels'       0                             'INT'
        };
 
 
@@ -52,10 +57,22 @@ opt= opt_proplistToStruct(varargin{:});
 [opt, isdefault]= opt_setDefaults(opt, props);
 opt_checkProplist(opt, props);
 
-
+% validate argument types
 misc_checkType(XTr, 'DOUBLE');
+
+if opt.nChannels ~= 0
+  misc_checkType(XTr, 'DOUBLE[- -]');
+end
+
 misc_checkType(YTr, 'DOUBLE[2 -]');
 misc_checkType(nSegments, 'INT');
+
+dims = size(XTr);
+
+% make data matrix 3D if it has been tranformed to 2D for crossvalidation
+if (length(size(XTr)) == 2) && opt.nChannels > 0
+  XTr = reshape(XTr, [], opt.nChannels, dims(2));
+end
 
 dims = size(XTr);
 
@@ -65,9 +82,13 @@ seg_idx = round(linspace(0, dims(1), nSegments+1));
 seg_scores = zeros(nSegments, dims(end));
 
 for i = 1:nSegments
-    seg = XTr(seg_idx(i) + 1 : seg_idx(i + 1), :, :); % i-th segment of X
+    if length(size(XTr)) > 2
+      seg = XTr(seg_idx(i) + 1 : seg_idx(i + 1), :, :); % i-th segment of X
+      seg = reshape(seg, [], dims(end));
+    else
+      seg = XTr(seg_idx(i) + 1 : seg_idx(i + 1), :); % i-th segment of X
+    end
     %train LDA classifier for this segment
-    seg = reshape(seg, [], dims(end));
     seg_LDA = train_RLDAshrink(seg, YTr, 'Scaling', 1);
     C.seg(i) = seg_LDA; 
     seg_scores(i,:) = apply_separatingHyperplane(seg_LDA, seg); %get classifier scores for segment
@@ -79,4 +100,9 @@ if opt.Regression
 else
     %LDA as top-level classifier
     C.final = train_RLDAshrink(seg_scores, YTr, 'Scaling', 1);
+end
+
+% add number of channels to classifier so they can be used in the apply function
+if opt.nChannels > 0
+  C.nChannels = opt.nChannels;
 end

--- a/classification/apply_HLDA.m
+++ b/classification/apply_HLDA.m
@@ -27,7 +27,7 @@ function out = apply_HLDA(C, X)
 %   apply_HLDA(C, X)
 %   
 %See also:
-%  HLDA 
+% train_HLDA 
 
 % validate argument types
 misc_checkType(C, 'STRUCT(seg final)');

--- a/classification/apply_HLDA.m
+++ b/classification/apply_HLDA.m
@@ -1,17 +1,17 @@
-function out = apply_HLDA(XTr, C)
+function out = apply_HLDA(C, X)
 % APPLY_HLDA - Hierarchical linear discriminant analysis 
 %
 %Synopsis:
-%   out = apply_HLDA(XTr, C)
+%   out = apply_HLDA(C, X)
 % 
 %Arguments:
-%   XTR: DOUBLE [TxNxM] - Data matrix, with T temporal features, N
-%                           N spatial features, and M 
-%                           training points/examples. 
 %   C: STRUCT           - a hierarchical LDA classifier structure that 
 %                           contains the individual segment classifiers and 
 %                           the top-level classifier. Must include the
-%                           fields 'seg' and 'final'
+%                           fields 'seg' and 'final'.
+%   X: DOUBLE [TxNxM] - Data matrix, with T temporal features, N
+%                           N spatial features, and M 
+%                           training points/examples. 
 %Returns:
 %   out: FLOAT[]        - an array containing the classifier score for each 
 %                           sample
@@ -24,26 +24,36 @@ function out = apply_HLDA(XTr, C)
 %   Systems and Rehabilitation Engineering 14, 174–179 (2006).
 %
 %Examples:
-%   apply_HLDA(XTr, C))
+%   apply_HLDA(C, X)
 %   
 %See also:
-%   TRAIN_HLDA
+%  HLDA 
 
-misc_checkType(XTr, 'DOUBLE');
+% validate argument types
 misc_checkType(C, 'STRUCT(seg final)');
+misc_checkType(X, 'DOUBLE');
+if isfield(C,'nChannels')
+  misc_checkType(X, 'DOUBLE[- -]');
+end
 
 
 nSegments = length(C.seg);
 
-dims = size(XTr);
+dims = size(X);
 
+% make data matrix 3D if it has been tranformed to 2D for crossvalidation
+if (length(size(X)) == 2) && isfield(C, 'nChannels')
+  X = reshape(X, [], C.nChannels, dims(2));
+end
+
+dims = size(X);
 %boundary indices between segments
 seg_idx = round(linspace(0, dims(1), nSegments+1));
 
 seg_scores = zeros(nSegments, dims(end));
 
 for i = 1:nSegments
-    seg = XTr(seg_idx(i) + 1 : seg_idx(i + 1), :, :); % i-th segment of X
+    seg = X(seg_idx(i) + 1 : seg_idx(i + 1), :, :); % i-th segment of X
     %apply LDA classifier for this segment
     seg = reshape(seg, [], dims(end));
     seg_scores(i,:) = apply_separatingHyperplane(C.seg(i), seg); %get classifier scores for segment
@@ -51,8 +61,13 @@ end
 
 if isfield(C.final, 'B')
     %logistic regression as top-level classifier
-    exps = C.final.B(1) + C.final.B(2:end)'*seg_scores;
-    out = 1./(1 + exp(-exps));
+%    exps = C.final.B(1) + C.final.B(2:end)'*seg_scores;
+%    out = 1./(1 + exp(-exps));
+
+    pihat = mnrval(C.final.B, seg_scores');
+
+    pihat = pihat';
+    out = pihat(1,:);
     %transform scores to interval [-1 1]
     out = -2*(out - 0.5);
 else

--- a/classification/train_HLDA.m
+++ b/classification/train_HLDA.m
@@ -1,8 +1,8 @@
-function C = HLDA(XTr, YTr, nSegments, varargin)
-% HLDA - Hierarchical linear discriminant analysis 
+function C = train_HLDA(XTr, YTr, nSegments, varargin)
+% TRAIN_HLDA - Hierarchical linear discriminant analysis 
 %
 %Synopsis:
-%   C = HLDA(XTr, YTr, nSegments, varargin)
+%   C = train_HLDA(XTr, YTr, nSegments, varargin)
 %
 %Arguments:
 %   XTR: DOUBLE [TxNxM] - Data matrix, with T temporal features, N
@@ -30,7 +30,7 @@ function C = HLDA(XTr, YTr, nSegments, varargin)
 %       'final': STRUCT       - the final top-level LDA classifier
 %       'nChannels': INT      - (optional) the number of channels in the training data
 %Description:
-%   HLDA trains a hierarchical LDA classifier given training data,
+%   train_HLDA trains a hierarchical LDA classifier given training data,
 %   labels and a number of segments. Either LDA (default) or logistic regression 
 %   is used as a top-level classifier.
 %
@@ -41,8 +41,8 @@ function C = HLDA(XTr, YTr, nSegments, varargin)
 %
 %
 %Examples:
-%   HLDA(XTr, YTr, nSegments)
-%   HLDA(XTr, YTr, nSegments, 'Regression', 1, 'nChannels', 64)
+%   train_HLDA(XTr, YTr, nSegments)
+%   train_HLDA(XTr, YTr, nSegments, 'Regression', 1, 'nChannels', 64)
 %   
 %See also:
 %   APPLY_HLDA


### PR DESCRIPTION
As with logisticRegression, the 'train_' prefix has been left out in order to make the function work with crossvalidation. After logisticRegression is added to the toolbox, the function can be modified to use logisticRegression internally.
