### PR TITLE
fixes bug in proc_appendChannels

### DIFF
--- a/misc/misc_history.m
+++ b/misc/misc_history.m
@@ -30,7 +30,7 @@ function obj = misc_history(obj)
 % 08-2012 Matthias Treder
 global BTB
 
-if ~isempty(BTB.History) && BTB.History==0
+if ~isempty(BTB.History) && BTB.History==0 ||isempty(obj)
   return
 end
 


### PR DESCRIPTION
fixes bug caused when proc_appendChannels is used with empty first argument and BTB.History==1 (and maybe other bugs, too)
I resolved it by making misc_history do nothing if the input is empty.

I think this makes sense in general, but the bug could also be fixed by changing proc_appendChannels to not evaluate misc_history if first argument is empty but I think it is better this way.
