### PR TITLE
Updates proc_cspAuto and proc_linearDerivation to keep original channels in orig.Clab in case of 

### DIFF
--- a/processing/proc_cspAuto.m
+++ b/processing/proc_cspAuto.m
@@ -211,7 +211,7 @@ end
 
 
 %% save old channel labels
-if isfield(dat, 'clab'),
+if isfield(dat, 'clab')  && ~isfield(dat, 'origClab'),
   dat.origClab= dat.clab;
 end
 

--- a/processing/proc_linearDerivation.m
+++ b/processing/proc_linearDerivation.m
@@ -97,4 +97,6 @@ else
   end
 end
 
-out.origClab= dat.clab;
+if ~isfield(dat, 'origClab')
+    out.origClab= dat.clab;
+end


### PR DESCRIPTION
Updates proc_cspAuto and proc_linearDerivation to keep original channels in orig.Clab in case of dimensionality reduction.
If I am correct, the orig.Clab should remain 'original', but for example in case of using SSD and CSP, the orig.Clab is defined in SSD and now is overwritten in the CSP.
So, I think is better to verify first if orig.Clab was already defined.
