### PR TITLE
Add control function for sending eyetracker and EEG cfy output via UDP: bbci_control_MSPilot

### DIFF
--- a/online/control/bbci_control_MSPilot.m
+++ b/online/control/bbci_control_MSPilot.m
@@ -1,0 +1,30 @@
+function [packet, state]= bbci_control_MSPilot(cfy_out, state, event, opt)
+%BBCI_CONTROL_MSPILOT Generate control signal for MindSee Pilot study
+% 
+%Synopsis:
+%  [PACKET, STATE]= bbci_control_XYZ(CFY_OUT, STATE, EVENT_INFO, <PARAMS>)
+%
+%Arguments:
+%  CFY_OUT - Output of the classifier
+%  STATE - Internal state variable, which is empty in the first call of a
+%      run of bbci_apply.
+%  EVENT_INFO - Structure that specifies the event (fields 'time' and 'desc')
+%      that triggered the evaluation of this control. Furthermore, EVENT_INFO
+%      contains the whole marker queue in the field 'all_markers'.
+%  PARAMS - Additional parameters that can be specified in bbci.control.param
+%      are passed as further arguments.
+%
+%Output:
+% PACKET: Variable/value list in a CELL defining the control signal that
+%     is to be sent via UDP to the application.
+% STATE: Updated internal state variable
+%
+% 02-2016 Jan Boelts
+
+if isfield(opt, 'fixx') && isfield(opt, 'fixy')
+    packet = {'x', opt.fixx, 'y', opt.fixy, 'cfy_out', cfy_out}; 
+else
+    packet = {'cfy_out', cfy_out}; 
+end
+end
+

--- a/online/control/bbci_control_MSPilot.m
+++ b/online/control/bbci_control_MSPilot.m
@@ -23,7 +23,7 @@ function [packet, state]= bbci_control_MSPilot(cfy_out, state, event, opt)
 
 % check whether there is eyetracker data
 if isfield(opt, 'fixx') && isfield(opt, 'fixy')
-    packet = {'x', opt.fixx, 'y', opt.fixy, 'cfy_out', cfy_out}; 
+    packet = {['x ' num2str(opt.fixx) ' y ' num2str(opt.fixy) ' cfy_out ' num2str(cfy_out)]}; 
 else
     packet = {'cfy_out', cfy_out}; 
 end

--- a/online/control/bbci_control_MSPilot.m
+++ b/online/control/bbci_control_MSPilot.m
@@ -21,6 +21,7 @@ function [packet, state]= bbci_control_MSPilot(cfy_out, state, event, opt)
 %
 % 02-2016 Jan Boelts
 
+% check whether there is eyetracker data
 if isfield(opt, 'fixx') && isfield(opt, 'fixy')
     packet = {'x', opt.fixx, 'y', opt.fixy, 'cfy_out', cfy_out}; 
 else

--- a/online/utils/selftesting/test_mspliot_sendControl.m
+++ b/online/utils/selftesting/test_mspliot_sendControl.m
@@ -1,0 +1,70 @@
+% test mindsee pilot control signal to processing visualization via udp. 
+
+BTB_memo= BTB;
+BTB.MatDir= fullfile(BTB.DataDir, 'demoMat');
+
+eeg_file= fullfile('VPiac_10_10_13', ...
+                   'calibration_CenterSpellerMVEP_VPiac');
+[cnt, mrk]= file_loadMatlab(eeg_file, 'vars',{'cnt','mrk'});
+
+clab= {'F3','Fz','F4', 'C3','Cz','C4', 'P3','Pz','P4'};
+ref_ival= [-200 0];
+cfy_ival= [90 110; 110 150; 150 250; 250 400; 400 750];
+% Generate random classifier of correct format
+C= struct('b',0);
+C.w= randn(length(clab)*size(cfy_ival,1), 1);
+
+bbci= struct;
+bbci.source.acquire_fcn= @bbci_acquire_offline;
+bbci.source.acquire_param= {cnt, mrk};
+
+bbci.signal.clab= clab;
+
+bbci.feature.proc= {{@proc_baseline, ref_ival}, ...
+                    {@proc_jumpingMeans, cfy_ival}};
+bbci.feature.ival= [ref_ival(1) cfy_ival(end)];
+
+bbci.classifier.C= C;
+
+bbci.control.fcn= @bbci_control_MSPilot;
+bbci.control.param= {struct('fixx' , 827, 'fixy', 66)};
+bbci.control.condition.marker= [11:16, 21:26, 31:36, 41:46];
+bbci.feedback.receiver = 'udp'; 
+
+bbci.quit_condition.marker= 255;
+bbci.quit_condition.running_time= 2*60;
+
+bbci.log.output= 'screen&file';
+bbci.log.file= fullfile(BTB.TmpDir, 'log');
+bbci.log.classifier= 1;
+
+data= bbci_apply_uni(bbci);
+% Of course, bbci_apply would do the very same.
+
+
+%% validate simulated online results with offline classification
+% read markers and classifier output from logfile
+log_format= '%fs | M(%u) | %fs | [%f] | %s';
+[time, marker_desc, marker_time, cfy, control]= ...
+    textread(data.log.filename, log_format, ...
+             'commentstyle','shell');
+
+% validate makers that evoked calculation of control signals
+isequal(marker_desc, mrk.event.desc(1:length(marker_desc)))
+
+% offline processing of the data
+epo= proc_segmentation(cnt, mrk, [ref_ival(1) cfy_ival(end)], 'clab', bbci.signal.clab);
+fv= proc_baseline(epo, ref_ival);
+fv= proc_jumpingMeans(fv, cfy_ival);
+out= applyClassifier(fv, bbci.classifier.C);
+
+% validate classifier outputs of simulated online and offline processing
+max(abs( out(1:length(cfy))' - cfy))
+
+% extract control signals
+isctrl= cellfun(@(x)(length(x)>2), control);
+control_str= sprintf('%s\n', control{find(isctrl)});
+[var_name, var_value]= strread(control_str, '{%s%f}', 'delimiter','=');
+var_value'
+
+BTB= BTB_memo;


### PR DESCRIPTION
the control function encodes eyetracker fixation data and eeg classifier output in a single string. The string can be sent via UDP. 
Also adds a test script that was adapted from `demo_bbcionline_apply_ERP_Speller`. This scripts just sends fixed fixation values and the ERP classifier output. 
