### PR TITLE
Bugfix in bbci_apply_recordSignals

### DIFF
--- a/online/apply_functions/bbci_apply_recordSignals.m
+++ b/online/apply_functions/bbci_apply_recordSignals.m
@@ -54,7 +54,7 @@ if ischar(varargin{1}),
     end
     switch(DS_record.fcn),
      case 'bv',
-      if DS_record.opt.checkimpedances,
+      if DS_record.opt.CheckImpedances,
         bvr_sendcommand('startimprecording', [filename '.eeg']);
       else
         bvr_sendcommand('startrecording', [filename '.eeg']);


### PR DESCRIPTION
Fixed wrong reference to opt.checkimpedances (instead of opt.CheckImedances).
