### PR TITLE
Bugfix

### DIFF
--- a/processing/proc_normalizeTimeFrequencyData.m
+++ b/processing/proc_normalizeTimeFrequencyData.m
@@ -46,12 +46,6 @@ end
 [opt, isdefault]= opt_setDefaults(opt, props);
 opt_checkProplist(opt, props);
 
-if not(ndims(dat.x) == 4)
-  error('dat.x must be 4-dimensional (time x frequency x channel x trials)');
-end
-
-
-% [T,~,nC,~]= size(dat.x);
 nC = size(dat,3);  
 switch(lower(opt.Pos)),
     case 'beginning_exact', % [-150 0] = 15 samples not 16 (at fs= 100 Hz)


### PR DESCRIPTION
fixed a problem in normalization of time-frequency data. 
I had to remove the dim-check to make it work with TF data that was averaged across trials and has only one channel, i.e. dat.x is only two dimensional in this case. Unfortunately there is no way to add singleton dimensions as the last dimensions to Matlab arrays, i.e. make them have size d1 x d2 x 1 x 1. 
Thus, I had to give up the sanity check to make it work. Not the optimal solution but the best I can think of currently...
