### PR TITLE
problems in proc_csp if whitening matrix does not have full rank

### DIFF
--- a/processing/utils/score_medianvar.m
+++ b/processing/utils/score_medianvar.m
@@ -1,8 +1,11 @@
-
 function score = score_medianvar(dat,W,~)
 %SCORE_MEDIANVAR - Median variance of projected components as score
 
 nChans = size(dat.x,2);
+
+if size(W,2)<nChans
+    nChans=size(W,2);
+end
 
 fv = proc_linearDerivation(dat,W);
 fv = proc_variance(fv);


### PR DESCRIPTION
When using `proc_csp` with the following parameters: 

```
'CovFcn',@cov,
'ScoreFcn',@score_medianvar
```

the whitening matrix M (proc_csp, l.74) might not have full rank anymore.
This results in an error in `score_medianvar` when doing the for loop over all channels, since not all channels are accessible anymore (because of `proc_linearDerivation(dat,W)`).
I added some code into `score_medianvar` to adapt the number of channels in case W is not quadratic.

```
if size(W,2)<nChans
    nChans=size(W,2);
end
```
