### PR TITLE
bug in proc_appendEpochs

### DIFF
--- a/processing/proc_appendEpochs.m
+++ b/processing/proc_appendEpochs.m
@@ -29,6 +29,7 @@ if iscell(epo1),
   for ii= 2:length(Cepo),
     epo1= proc_appendEpochs(epo1, Cepo{ii});
   end
+  epo=epo1;
   return
 end
   

--- a/processing/utils/score_medianvar.m
+++ b/processing/utils/score_medianvar.m
@@ -1,8 +1,11 @@
-
 function score = score_medianvar(dat,W,~)
 %SCORE_MEDIANVAR - Median variance of projected components as score
 
 nChans = size(dat.x,2);
+
+if size(W,2)<nChans
+    nChans=size(W,2);
+end
 
 fv = proc_linearDerivation(dat,W);
 fv = proc_variance(fv);


### PR DESCRIPTION
When the input of proc_appendEpochs is a cell, the function does not assign the output. I have added `epo=epo1;` in line 32, equivalent to line 41.