### PR TITLE
Add option to standardize data before obtaining shrinkage gamma

### DIFF
--- a/classification/utils/clsutil_shrinkage.m
+++ b/classification/utils/clsutil_shrinkage.m
@@ -13,6 +13,9 @@ function [Cstar, gamma, T] = clsutil_shrinkage(X, varargin)
 %      'C' (common covariance)
 %      'D' (diagonal, unequal variance)
 %    'Gamma': DOUBLE - Shrinkage parameter. May be used to set the shrinkage parameter explicitly.
+%    'Standardize': BOOL (default 0) - If set, standardizes dimensions before calculating optimal
+%                   Shrinkage gamma. The obtained covariance matrix is scaled back into the
+%                   original feature range.
 %    'Verbose': BOOL (default 0) - If set, verbose mode is activated
 %
 %Returns:
@@ -44,9 +47,10 @@ function [Cstar, gamma, T] = clsutil_shrinkage(X, varargin)
 % opt-type checking (Michael Tangermann)
 
 
-props= {'Target'     'B'     'CHAR(A B C D)'
-        'Gamma'      'auto'  'CHAR(auto)|!DOUBLE'
-        'Verbose'    0       'BOOL'};
+props= {'Target'      'B'     'CHAR(A B C D)'
+        'Gamma'       'auto'  'CHAR(auto)|!DOUBLE'
+        'Standardize' 0       'BOOL'
+        'Verbose'     0       'BOOL'};
 
 if nargin==0,
   Cstar= props;
@@ -66,6 +70,9 @@ end
   
 %%% Empirical covariance
 [p, n] = size(X);
+if opt.Standardize
+    [X, ~, z_sigma] = zscore(X, 0, 2);
+end
 Xn     = X - repmat(mean(X,2), [1 n]);
 S      = Xn*Xn';
 Xn2    = Xn.^2;
@@ -112,3 +119,6 @@ end
 
 %%% Estimate covariance matrix
 Cstar = (gamma*T + (1-gamma)*S ) / (n-1);
+if opt.Standardize
+     Cstar = (z_sigma * z_sigma') .* Cstar;
+end


### PR DESCRIPTION
Similarly to the default LDA implementation is sklearn (see [here](https://github.com/scikit-learn/scikit-learn/blob/95d4f0841d57e8b5f6b2a570312e9d832e69debc/sklearn/discriminant_analysis.py#L53-L58)) this PR exposes the option to standardize the feature dimensions before obtaining the shrinkage gamma.

We found that this improves classification performance slightly, especially when feature dimensions have largely differing scale. This can be the case when one channel with bad impedance shows much higher variation than the other channels, but this channel cannot be rejected for some reason.
While we always standardize before calculating shrinkage amount, the default is set to 0/false to not interfere with existing code bases.